### PR TITLE
Support new EEPROM firmware repository structure

### DIFF
--- a/app/Http/Livewire/Firmwares.php
+++ b/app/Http/Livewire/Firmwares.php
@@ -39,7 +39,7 @@ class Firmwares extends Component
             if (!$prefix)
                 throw new \Exception("Error listing .zip file");
 
-            $prefix .= "firmware/";
+            $prefix .= "firmware-2711/";
 
             for ($i = 1; $i < $zip->numFiles; $i++)
             {

--- a/app/Http/Livewire/Projects.php
+++ b/app/Http/Livewire/Projects.php
@@ -19,7 +19,7 @@ class Projects extends Component
     public $projects, $activeProject;
     public $projectid, $name, $device, $storage, $image_id, $label_id, $label_moment, $selectedScripts, $offerSettingsReset;
     public $firmware, $eeprom_settings, $verify;
-    public $images, $labels, $scripts, $beta_firmware, $stable_firmware;
+    public $images, $labels, $scripts, $stable_firmware;
 
     protected $rules = [
         'name' => 'required|max:255',
@@ -41,8 +41,7 @@ class Projects extends Component
         $this->images = Image::orderBy('filename')->orderBy('id')->get();
         $this->labels = Label::orderBy('name')->get();
         $this->scripts = Script::orderBy('name')->get();
-        $this->beta_firmware = Firmware::allOfChannel('beta');
-        $this->stable_firmware = Firmware::allOfChannel('stable');        
+        $this->stable_firmware = Firmware::allOfChannel('latest');
 
         if ($this->isOpen && $this->label_moment != 'never' && !$this->label_id && count($this->labels))
             $this->label_id = $this->labels[0]->id;

--- a/app/Models/Firmware.php
+++ b/app/Models/Firmware.php
@@ -33,7 +33,7 @@ class Firmware
     public static function all()
     {
         $entries = [];
-        $channels = ["stable", "beta"];
+        $channels = ["latest"];
 
         foreach ($channels as $channel)
         {

--- a/resources/views/livewire/editproject.blade.php
+++ b/resources/views/livewire/editproject.blade.php
@@ -48,13 +48,6 @@
                         @endforeach
                       </optgroup>
                       @endif
-                      @if (count($beta_firmware))
-                      <optgroup label="beta">
-                        @foreach ($beta_firmware as $fw)
-                        <option value="{{ $fw->path }}">{{ $fw->name }}</option>
-                        @endforeach
-                      </optgroup>
-                      @endif
                   </select>
                   @error('firmware') <span class="text-red-500">{{ $message }}</span>@enderror
               </div>


### PR DESCRIPTION
The structure of [rpi-eeprom](https://github.com/raspberrypi/rpi-eeprom) changed recently, preventing the "Download new firmware from github" feature on the /firmware webpage from working. This PR updates cmprovision to be compatible with the new rpi-eeprom structure. It also removes the concept of beta firmwares as these will no longer be included on the rpi-eeprom master branch.

See https://github.com/raspberrypi/rpi-eeprom/commit/299b1c7e120728098d3fc68ee16eb6a2355d33af for more information on the changes to rpi-eeprom.